### PR TITLE
feat: limited viewing options for visitors of profile through link/url

### DIFF
--- a/src/components/header/header.jsx
+++ b/src/components/header/header.jsx
@@ -19,38 +19,37 @@ import Typography from "@material-ui/core/Typography";
 import { toggleSideBar } from "../../redux/actions/side-actions";
 import { useDispatch, useSelector } from "react-redux";
 import {Link, useLocation} from "react-router-dom";
-import Cookies from 'js-cookie';
 import { AuthContext } from '../../shared/contexts/authContext';
 import { removeCookies } from "../../shared/lib/authentication";
 import routes from "../../routes";
-import { isCurrentUser, saveUser, setUserId } from "../../redux/actions/user-actions";
+import { isCurrentUser, setUserId } from "../../redux/actions/user-actions";
 
-export default function Header(props) {
+export default function Header() {
   const location = useLocation();
   const classes = useStyles();
   const [profileMenu, setProfileMenu] = useState(null);
   const {isSidebarOpened} = useSelector(state => state.sidebar);
   const {user, userId} = useSelector(state => state.user);
-  const currentUserInfo = useSelector(state => state.user.user);
   const { setUser, setTokens } = useContext(AuthContext);
   const dispatch = useDispatch();
+  const [idFromUrl, setIdFromUrl] = useState('');
   const [isLayoutRender,setIsLayoutRender] = useState(false);
   const shouldLayoutRender = (pathname)=>{
     if(pathname === routes.LOGIN || pathname === routes.NEW_ACCOUNT || pathname.includes('/join') )
       return false;
     return true;
   }
-  const userIdFromCookies = Cookies.get('userid');
 
   useEffect(() => {
     dispatch(setUserId());
-    dispatch(saveUser(userIdFromCookies));
-  }, [dispatch, userIdFromCookies]);
+  }, [dispatch]);
 
   useEffect(() => {
-    dispatch(isCurrentUser(userId, userIdFromCookies));
+    const arr = location.pathname.split('/');
+    setIdFromUrl(arr[arr.length - 1]);
+    dispatch(isCurrentUser(userId, idFromUrl));
     setIsLayoutRender(shouldLayoutRender(location.pathname));
-  }, [location, userIdFromCookies, dispatch, userId ]);
+  }, [location, idFromUrl, dispatch, userId ]);
 
   const toggleMenuItem = () => {
     dispatch(toggleSideBar());
@@ -137,7 +136,7 @@ export default function Header(props) {
               classes.profileMenuItem,
               classes.headerMenuItem
             )}
-            to={`${routes.PROFILE}/${currentUserInfo?.userName ? currentUserInfo.userName : 'dummy-userName'}`}
+            to={`${routes.PROFILE}/${userId}`}
           >
             <MenuItem>
               <AccountIcon className={classes.profileMenuIcon} /> Profile

--- a/src/components/home/home.jsx
+++ b/src/components/home/home.jsx
@@ -2,7 +2,21 @@ import React, { useEffect } from 'react';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import * as Auth from '../../shared/lib/authentication'
-const Welcome = () => {   
+import { saveUser } from '../../redux/actions/user-actions';
+import { useDispatch, useSelector } from 'react-redux';
+import Cookies from 'js-cookie';
+
+const Welcome = () => {
+  const userIdFromCookies = Cookies.get('userid');
+  const dispatch = useDispatch();
+  const {isCurrentUser} = useSelector(state => state.user);
+
+  useEffect(() => {
+    if (!isCurrentUser) {
+      dispatch(saveUser(userIdFromCookies));
+    }
+  }, [dispatch]);
+
     useEffect(() => {
         Auth.getProfile().then((teachers)=>{
             console.log("Teachers " + JSON.stringify(teachers))

--- a/src/components/profile/Profile.jsx
+++ b/src/components/profile/Profile.jsx
@@ -1,15 +1,27 @@
-import React from 'react';
-import { useSelector } from "react-redux";
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from "react-redux";
 import { Grid } from "@material-ui/core";
 
 import Header from "./header/Header";
 import EditPublicInfo from "./forms/edit-public-info/EditPublicInfo";
 import EditPrivateInfo from "./forms/edit-private-info/EditPrivateInfo";
 import Loading from "../../shared/components/loader/Loading";
+import { useParams } from 'react-router-dom';
+import { isCurrentUser, saveUser } from '../../redux/actions/user-actions';
 
 
 const Profile = () => {
-  const {loading, isCurrentUser: isRenderForm} = useSelector((state) => state.user);
+  const { id } = useParams();
+  const { loading, userId, isCurrentUser: isRenderForm } = useSelector((state) => state.user);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(saveUser(id));
+  }, [dispatch, id]);
+
+  useEffect(() => {
+    dispatch(isCurrentUser(userId, id));
+  }, [dispatch, loading, userId, id]);
 
   if (loading) {
     return (

--- a/src/components/sidebar/sidebar.jsx
+++ b/src/components/sidebar/sidebar.jsx
@@ -15,7 +15,7 @@ import {
 } from "../../shared/svgs/menu-items";
 import { ArrowBack as ArrowBackIcon } from "@material-ui/icons";
 import { useTheme } from "@material-ui/styles";
-import { withRouter } from "react-router-dom";
+import { useLocation, withRouter } from "react-router-dom";
 import classNames from "classnames";
 import useStyles from "./styles";
 import SidebarLink from "./components/SidebarLink/SidebarLink";
@@ -27,7 +27,7 @@ import Button from "@material-ui/core/Button";
 import JoinTribeModal from "./modals/join-tribe";
 import routes from "../../routes";
 
-const structure = [
+let sidebarStructure = [
   { id: 0, label: "Home", link: "/home", icon: <HomeSVG /> },
   {
     id: 1,
@@ -57,6 +57,10 @@ const structure = [
   { id: 8, label: "Feedback", link: "/", icon: <FeedbackSvg /> },
 ];
 
+let protectedSidebarStructure = [
+  { id: 0, label: "Home", link: "/home", icon: <HomeSVG /> },
+];
+
 function Sidebar({ location }) {
   var classes = useStyles();
   var theme = useTheme();
@@ -72,6 +76,20 @@ function Sidebar({ location }) {
       return false;
     return true;  
   }
+
+  let structure;
+  let isShowJoinTribeIcon;
+  const { isCurrentUser } = useSelector((state) => state.user);
+  const isProfileURL = useLocation().pathname.includes('/profile');
+
+  if (!isCurrentUser && isProfileURL) {
+    isShowJoinTribeIcon = false;
+    structure = protectedSidebarStructure;
+  } else {
+    isShowJoinTribeIcon = true;
+    structure = sidebarStructure;
+  }
+
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
@@ -142,7 +160,7 @@ function Sidebar({ location }) {
         </div>
 
         <List className={classes.sidebarList}>
-          <div className="newpopupdiv">
+          {isShowJoinTribeIcon && <div className="newpopupdiv">
             <Button
               className={isSidebarOpened ? "open" : "close"}
               aria-describedby={id}
@@ -174,7 +192,7 @@ function Sidebar({ location }) {
                 </button>
               </Typography>
             </Popover>
-          </div>
+          </div>}
           {structure.map((link) => (
             <SidebarLink
               key={link.label + link.id}

--- a/src/routes.js
+++ b/src/routes.js
@@ -8,7 +8,7 @@ export default {
     RESET: '/reset',
     TRIBE: '/tribe',
     PROFILE: '/profile',
-    PROFILE_ID: '/profile/:userName',
+    PROFILE_ID: '/profile/:id',
     JOIN_TRIBE_ID:'/join/:id',
     TRIBE_PROFILE: '/tribe-profile/:id'
 };


### PR DESCRIPTION
When a user uses a link to someone else's profile, he will be limited to the choice of elements in the sidebar, for further progress through the application. Now I have left only a link to the home page when going to which, the current user will be updated in the redax store.

I had to return the use of the userId in the url, since the previous implementation would not be correct, but it is not practical, I will try to find a solution in the near time.



